### PR TITLE
Feature/adjust resistenztestung (task #10687)

### DIFF
--- a/Examples/2 - Antrag - Example.json
+++ b/Examples/2 - Antrag - Example.json
@@ -2069,9 +2069,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie EGFR-TKI"
-                        },
+                        "valueString": "1 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2088,9 +2086,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie EGFR-TKI"
-                        },
+                        "valueString": "2 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2107,9 +2103,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie EGFR-TKI"
-                        },
+                        "valueString": "3 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2126,9 +2120,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie EGFR-TKI"
-                        },
+                        "valueString": "4 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2185,9 +2177,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ALK-TKI"
-                        },
+                        "valueString": "1 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2204,9 +2194,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ALK-TKI"
-                        },
+                        "valueString": "2 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2223,9 +2211,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ALK-TKI"
-                        },
+                        "valueString": "3 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2242,9 +2228,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ALK-TKI"
-                        },
+                        "valueString": "4 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2312,9 +2296,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ROS1-TKI"
-                        },
+                        "valueString": "1 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2331,9 +2313,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ROS1-TKI"
-                        },
+                        "valueString": "2 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2350,9 +2330,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ROS1-TKI"
-                        },
+                        "valueString": "3 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2369,9 +2347,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ROS1-TKI"
-                        },
+                        "valueString": "4 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2703,9 +2679,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "1 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2722,9 +2696,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "2 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2741,9 +2713,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "3 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2760,9 +2730,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "4 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",

--- a/Examples/2 - Antrag Pseudonymisiert - Example.json
+++ b/Examples/2 - Antrag Pseudonymisiert - Example.json
@@ -1978,9 +1978,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie EGFR-TKI"
-                        },
+                        "valueString": "1 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -1997,9 +1995,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie EGFR-TKI"
-                        },
+                        "valueString": "2 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2016,9 +2012,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie EGFR-TKI"
-                        },
+                        "valueString": "3 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2035,9 +2029,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie EGFR-TKI"
-                        },
+                        "valueString": "4 Therapie EGFR-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2094,9 +2086,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ALK-TKI"
-                        },
+                        "valueString": "1 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2113,9 +2103,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ALK-TKI"
-                        },
+                        "valueString": "2 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2132,9 +2120,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ALK-TKI"
-                        },
+                        "valueString": "3 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2151,9 +2137,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ALK-TKI"
-                        },
+                        "valueString": "4 Therapie ALK-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2221,9 +2205,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ROS1-TKI"
-                        },
+                        "valueString": "1 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2240,9 +2222,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ROS1-TKI"
-                        },
+                        "valueString": "2 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2259,9 +2239,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ROS1-TKI"
-                        },
+                        "valueString": "3 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2278,9 +2256,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ROS1-TKI"
-                        },
+                        "valueString": "4 Therapie ROS1-TKI",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2612,9 +2588,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "1 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "1 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2631,9 +2605,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "2 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "2 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2650,9 +2622,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "3 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "3 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",
@@ -2669,9 +2639,7 @@
                                 }
                             ]
                         },
-                        "valueCodeableConcept": {
-                            "text": "4 Therapie ROS1-TKI Biopsie2"
-                        },
+                        "valueString": "4 Therapie ROS1-TKI Biopsie2",
                         "extension": [
                             {
                                 "url": "http://uk-koeln.de/fhir/StructureDefinition/Extension/nNGM/observation-component-order",

--- a/Profile-observation-nngm-tkiResistenz.xml
+++ b/Profile-observation-nngm-tkiResistenz.xml
@@ -208,7 +208,7 @@
     <element id="Observation.component:tkiTherapie.value[x]">
       <path value="Observation.component.value[x]" />
       <type>
-        <code value="CodeableConcept" />
+        <code value="string" />
       </type>
     </element>
   </differential>


### PR DESCRIPTION
This branch fixes the tkiTherapie component to use valueString instead of valueCodeableConcept so that we don't have to map strings to valueCodeableConcept.text. I updated the corresponding examples accordingly.

Please note: The Mutations (Exon, HGVSc and HGVSp) are called "EGFR-Mutations" in the CDS and thus are only needed for the EGFR-Observation. (So no changes there)